### PR TITLE
fix: Remove extra `/sshed` on the `go get` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -sf https://gobinaries.com/trntv/sshed | sh
 ```
 or install with ``go get``
 ```
-go get -u github.com/trntv/sshed/sshed
+go get -u github.com/trntv/sshed
 ```
 
 # Features


### PR DESCRIPTION
I tried installing this with go get and noticed there was an extra `/sshed` on the end of the command.

```sh
gsteve@benny-manjaro-kde ~ (master)> go get -u github.com/trntv/sshed/sshed
go: downloading github.com/trntv/sshed v0.0.0-20210426073901-218cb677f571
go get: module github.com/trntv/sshed@upgrade found (v0.0.0-20210426073901-218cb677f571), but doesnot contain package github.com/trntv/sshed/sshed
gsteve@benny-manjaro-kde ~ (master) [1]> go get -u github.com/trntv/sshed
gsteve@benny-manjaro-kde ~ (master)>
```

Look forward to trying this, thank you!