### PR TITLE
Fixed red terminal bug on exit

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -77,6 +77,8 @@ func main() {
 
 	if err != nil {
 		fmt.Println(ansi.Red, fmt.Sprintf("Error: %s", err))
+                reset := ansi.ColorCode("reset")
+                fmt.Println(reset)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixed that annoying bug, which sets the terminal character color to red, when exiting from hosts list view (sshed to) using keyboard shortcut Ctrl+C.

[Reference](https://github.com/mgutz/ansi?tab=readme-ov-file#example) 


**Before**

![image](https://github.com/trntv/sshed/assets/78214540/9b84fa4e-f5c7-4d7b-9494-c636f6b63415)


**After**
![image](https://github.com/trntv/sshed/assets/78214540/26572df2-f48d-44cf-a0c3-e2d15865f21a)

